### PR TITLE
Add modal editing UI for tasks

### DIFF
--- a/src/components/TaskEditModal.tsx
+++ b/src/components/TaskEditModal.tsx
@@ -1,0 +1,201 @@
+import { type MouseEvent, useEffect, useMemo, useState } from 'react';
+import { createPortal } from 'react-dom';
+import RichTextEditor from './RichTextEditor';
+import { CATEGORIES, STATUSES } from '../hooks/useTaskBoard';
+import type { Task, TaskCategory, TaskStatus, TaskTimer, TaskUpdate } from '../types';
+
+interface TaskEditModalProps {
+  task: Task;
+  isOpen: boolean;
+  onClose: () => void;
+  onUpdate: (id: string, updates: TaskUpdate) => void;
+  onMove: (id: string, status: TaskStatus) => void;
+  onArchive: (id: string) => void;
+  container?: Element | null;
+}
+
+const statusOrder: TaskStatus[] = STATUSES.map((status) => status.id);
+
+const TaskEditModal = ({
+  task,
+  isOpen,
+  onClose,
+  onUpdate,
+  onMove,
+  onArchive,
+  container
+}: TaskEditModalProps) => {
+  const [title, setTitle] = useState(task.title);
+  const [category, setCategory] = useState<TaskCategory>(task.category);
+  const [content, setContent] = useState(task.content);
+  const [durationMinutes, setDurationMinutes] = useState<number>(task.timer?.durationMinutes ?? 30);
+
+  useEffect(() => {
+    if (!isOpen) {
+      return;
+    }
+
+    setTitle(task.title);
+    setCategory(task.category);
+    setContent(task.content);
+    setDurationMinutes(task.timer?.durationMinutes ?? 30);
+  }, [isOpen, task]);
+
+  useEffect(() => {
+    if (!isOpen) {
+      return;
+    }
+
+    const handleKeyDown = (event: KeyboardEvent) => {
+      if (event.key === 'Escape') {
+        onClose();
+      }
+    };
+
+    window.addEventListener('keydown', handleKeyDown);
+
+    return () => {
+      window.removeEventListener('keydown', handleKeyDown);
+    };
+  }, [isOpen, onClose]);
+
+  const moveTargets = useMemo(() => {
+    const index = statusOrder.indexOf(task.status);
+    return {
+      prev: index > 0 ? statusOrder[index - 1] : null,
+      next: index < statusOrder.length - 1 ? statusOrder[index + 1] : null
+    };
+  }, [task.status]);
+
+  if (!isOpen) {
+    return null;
+  }
+
+  const handleOverlayClick = (event: MouseEvent<HTMLDivElement>) => {
+    if (event.target === event.currentTarget) {
+      onClose();
+    }
+  };
+
+  const handleSave = () => {
+    onUpdate(task.id, {
+      title,
+      category,
+      content,
+      timer: task.timer ? { ...task.timer, durationMinutes } : undefined
+    });
+    onClose();
+  };
+
+  const handleStartTimer = () => {
+    if (!durationMinutes || durationMinutes <= 0) {
+      return;
+    }
+
+    const timer: TaskTimer = {
+      durationMinutes,
+      startedAt: Date.now()
+    };
+
+    onUpdate(task.id, { timer });
+  };
+
+  const handleResetTimer = () => {
+    onUpdate(task.id, { timer: null });
+  };
+
+  const modalContent = (
+    <div className="modal-overlay" role="presentation" onClick={handleOverlayClick}>
+      <div
+        className="modal"
+        role="dialog"
+        aria-modal="true"
+        aria-labelledby={`task-modal-${task.id}`}
+        onClick={(event) => event.stopPropagation()}
+      >
+        <header className="modal-header">
+          <h2 id={`task-modal-${task.id}`}>Редактирование задачи</h2>
+          <button type="button" className="modal-close" onClick={onClose} aria-label="Закрыть">
+            ×
+          </button>
+        </header>
+
+        <div className="modal-task-meta">
+          <span className="modal-task-status">Статус: {STATUSES.find((status) => status.id === task.status)?.label}</span>
+          <div className="modal-task-actions">
+            {moveTargets.prev && (
+              <button type="button" onClick={() => onMove(task.id, moveTargets.prev!)}>
+                Перенести в «{STATUSES.find((status) => status.id === moveTargets.prev)?.label}»
+              </button>
+            )}
+            {moveTargets.next && (
+              <button type="button" onClick={() => onMove(task.id, moveTargets.next!)}>
+                Перенести в «{STATUSES.find((status) => status.id === moveTargets.next)?.label}»
+              </button>
+            )}
+            <button type="button" onClick={() => onArchive(task.id)}>
+              Архивировать
+            </button>
+          </div>
+        </div>
+
+        <div className="modal-body">
+          <label className="field">
+            <span>Название</span>
+            <input value={title} onChange={(event) => setTitle(event.target.value)} />
+          </label>
+          <label className="field">
+            <span>Категория</span>
+            <select value={category} onChange={(event) => setCategory(event.target.value as TaskCategory)}>
+              {CATEGORIES.map((item) => (
+                <option key={item.id} value={item.id}>
+                  {item.label}
+                </option>
+              ))}
+            </select>
+          </label>
+          <label className="field">
+            <span>Описание</span>
+            <RichTextEditor value={content} onChange={setContent} ariaLabel="Описание задачи" />
+          </label>
+          <div className="modal-timer">
+            <label className="field">
+              <span>Таймер (минут)</span>
+              <input
+                type="number"
+                min={1}
+                value={durationMinutes}
+                onChange={(event) => setDurationMinutes(Number(event.target.value))}
+              />
+            </label>
+            <div className="modal-timer-actions">
+              <button type="button" onClick={handleStartTimer}>
+                Запустить таймер
+              </button>
+              {task.timer && (
+                <button type="button" onClick={handleResetTimer}>
+                  Сбросить таймер
+                </button>
+              )}
+            </div>
+          </div>
+        </div>
+
+        <footer className="modal-footer">
+          <button type="button" onClick={handleSave} className="primary">
+            Сохранить
+          </button>
+          <button type="button" onClick={onClose} className="secondary">
+            Отмена
+          </button>
+        </footer>
+      </div>
+    </div>
+  );
+
+  const target = container ?? (typeof document !== 'undefined' ? document.body : null);
+
+  return target ? createPortal(modalContent, target) : null;
+};
+
+export default TaskEditModal;

--- a/src/styles.css
+++ b/src/styles.css
@@ -213,6 +213,141 @@ body {
   background: #f97316;
 }
 
+.modal-overlay {
+  position: fixed;
+  inset: 0;
+  background: rgba(15, 23, 42, 0.45);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 1.5rem;
+  z-index: 1000;
+}
+
+.modal {
+  background: #fff;
+  border-radius: 1rem;
+  width: min(680px, 100%);
+  max-height: 90vh;
+  overflow: hidden;
+  display: flex;
+  flex-direction: column;
+  box-shadow: 0 24px 48px rgba(15, 23, 42, 0.18);
+}
+
+.modal-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding: 1.25rem 1.5rem;
+  border-bottom: 1px solid #e2e8f0;
+}
+
+.modal-header h2 {
+  margin: 0;
+  font-size: 1.25rem;
+}
+
+.modal-close {
+  background: transparent;
+  border: none;
+  font-size: 1.5rem;
+  cursor: pointer;
+  line-height: 1;
+  color: #475569;
+}
+
+.modal-task-meta {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+  padding: 1rem 1.5rem 0;
+}
+
+.modal-task-status {
+  font-size: 0.95rem;
+  color: #475569;
+}
+
+.modal-task-actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+}
+
+.modal-task-actions button {
+  background: #e2e8f0;
+  border: none;
+  border-radius: 0.5rem;
+  padding: 0.45rem 0.75rem;
+  cursor: pointer;
+  font-size: 0.9rem;
+}
+
+.modal-body {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+  padding: 1.5rem;
+  overflow-y: auto;
+}
+
+.modal-timer {
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+}
+
+.modal-timer-actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+}
+
+.modal-timer-actions button {
+  background: #6366f1;
+  color: #fff;
+  border: none;
+  border-radius: 0.5rem;
+  padding: 0.5rem 0.75rem;
+  cursor: pointer;
+}
+
+.modal-timer-actions button:nth-of-type(2) {
+  background: #f97316;
+}
+
+.modal-footer {
+  display: flex;
+  justify-content: flex-end;
+  gap: 0.75rem;
+  padding: 1.25rem 1.5rem;
+  border-top: 1px solid #e2e8f0;
+}
+
+.modal-footer .primary,
+.modal-footer .secondary {
+  border: none;
+  border-radius: 0.5rem;
+  padding: 0.6rem 1.1rem;
+  cursor: pointer;
+  font-weight: 600;
+}
+
+.modal-footer .primary {
+  background: #6366f1;
+  color: #fff;
+}
+
+.modal-footer .secondary {
+  background: #e2e8f0;
+  color: #0f172a;
+}
+
+.modal-footer .secondary:hover {
+  background: #cbd5f5;
+}
+
 .timer {
   display: flex;
   flex-direction: column;


### PR DESCRIPTION
## Summary
- introduce a reusable TaskEditModal component with fields for title, category, description, and timer controls
- refactor TaskCard to open the modal for edits and wire movement/archive/update handlers
- add styling for the modal overlay, layout, and actions

## Testing
- npx vitest run

------
https://chatgpt.com/codex/tasks/task_e_68dea50c118c83258ad7a004b51b7ecd