### PR TITLE
Add floating task creation modal

### DIFF
--- a/src/__tests__/Board.test.tsx
+++ b/src/__tests__/Board.test.tsx
@@ -1,11 +1,22 @@
 import { describe, expect, beforeEach, vi, afterEach, it } from 'vitest';
-import { render, screen, within } from '@testing-library/react';
+import { render, screen, within, cleanup } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import App from '../App';
 
 const getColumn = (name: string) => {
   const heading = screen.getAllByRole('heading', { name })[0];
   return heading.closest('section') as HTMLElement;
+};
+
+const createTask = async (user: ReturnType<typeof userEvent.setup>, title: string) => {
+  await user.click(screen.getByRole('button', { name: 'Создать задачу' }));
+
+  const modal = screen.getByRole('dialog', { name: 'Новая задача' });
+  const titleInput = within(modal).getByLabelText('Название');
+
+  await user.clear(titleInput);
+  await user.type(titleInput, title);
+  await user.click(within(modal).getByRole('button', { name: 'Создать' }));
 };
 
 describe('Доска задач PinTaker', () => {
@@ -17,11 +28,10 @@ describe('Доска задач PinTaker', () => {
     const user = userEvent.setup();
     render(<App />);
 
-    const newColumn = getColumn('Новый');
-    const titleInput = within(newColumn).getByPlaceholderText('Название задачи');
+    await createTask(user, 'Написать документацию');
+    await screen.findByRole('heading', { name: 'Написать документацию' });
 
-    await user.type(titleInput, 'Написать документацию');
-    await user.click(within(newColumn).getByRole('button', { name: 'Добавить' }));
+    const newColumn = getColumn('Новый');
 
     expect(within(newColumn).getByRole('heading', { name: 'Написать документацию' })).toBeVisible();
   });
@@ -30,11 +40,10 @@ describe('Доска задач PinTaker', () => {
     const user = userEvent.setup();
     render(<App />);
 
-    const newColumn = getColumn('Новый');
-    const titleInput = within(newColumn).getByPlaceholderText('Название задачи');
+    await createTask(user, 'Починить сборку');
+    await screen.findByRole('heading', { name: 'Починить сборку' });
 
-    await user.type(titleInput, 'Починить сборку');
-    await user.click(within(newColumn).getByRole('button', { name: 'Добавить' }));
+    const newColumn = getColumn('Новый');
 
     const createdHeading = within(newColumn).getByRole('heading', { name: 'Починить сборку' });
     const card = createdHeading.closest('article') as HTMLElement;
@@ -58,11 +67,9 @@ describe('Доска задач PinTaker', () => {
     const user = userEvent.setup({ advanceTimers: vi.advanceTimersByTime });
     render(<App />);
 
-    const newColumn = getColumn('Новый');
-    const titleInput = within(newColumn).getByPlaceholderText('Название задачи');
+    await createTask(user, 'Проверить отчёт');
 
-    await user.type(titleInput, 'Проверить отчёт');
-    await user.click(within(newColumn).getByRole('button', { name: 'Добавить' }));
+    const newColumn = getColumn('Новый');
 
     const heading = within(newColumn).getByRole('heading', { name: 'Проверить отчёт' });
     const card = heading.closest('article') as HTMLElement;
@@ -81,6 +88,7 @@ describe('Доска задач PinTaker', () => {
   });
 
   afterEach(() => {
+    cleanup();
     vi.useRealTimers();
   });
 });

--- a/src/components/Board.tsx
+++ b/src/components/Board.tsx
@@ -1,35 +1,30 @@
 import { useState } from 'react';
 import Column from './Column';
+import TaskModal from './TaskModal';
 import { useTaskBoard, STATUSES } from '../hooks/useTaskBoard';
-import type { TaskCategory, TaskStatus } from '../types';
+import type { TaskCategory } from '../types';
 
 const Board = () => {
   const { activeTasks, archivedTasks, addTask, restoreTask } = useTaskBoard();
-  const [draftTitles, setDraftTitles] = useState<Record<TaskStatus, string>>({
-    'new': '',
-    'in-progress': '',
-    'done': ''
-  });
-  const [draftCategories, setDraftCategories] = useState<Record<TaskStatus, TaskCategory>>({
-    'new': 'development',
-    'in-progress': 'development',
-    'done': 'development'
-  });
+  const [isModalOpen, setModalOpen] = useState(false);
 
-  const handleCreateTask = (status: TaskStatus) => {
-    const title = draftTitles[status].trim();
-    if (!title) {
-      return;
-    }
-
+  const handleCreateTask = ({
+    title,
+    category,
+    content
+  }: {
+    title: string;
+    category: TaskCategory;
+    content: string;
+  }) => {
     addTask({
       title,
-      status,
-      category: draftCategories[status],
-      content: '<p>Нажмите, чтобы отредактировать описание задачи.</p>'
+      status: 'new',
+      category,
+      content
     });
 
-    setDraftTitles((prev) => ({ ...prev, [status]: '' }));
+    setModalOpen(false);
   };
 
   return (
@@ -41,18 +36,22 @@ const Board = () => {
             status={id}
             title={label}
             tasks={activeTasks.filter((task) => task.status === id)}
-            draftTitle={draftTitles[id]}
-            onDraftTitleChange={(value) =>
-              setDraftTitles((prev) => ({ ...prev, [id]: value }))
-            }
-            draftCategory={draftCategories[id]}
-            onDraftCategoryChange={(value) =>
-              setDraftCategories((prev) => ({ ...prev, [id]: value }))
-            }
-            onCreateTask={() => handleCreateTask(id)}
           />
         ))}
       </div>
+      <button
+        type="button"
+        className="board-create-fab"
+        aria-label="Создать задачу"
+        onClick={() => setModalOpen(true)}
+      >
+        +
+      </button>
+      <TaskModal
+        isOpen={isModalOpen}
+        onClose={() => setModalOpen(false)}
+        onCreate={handleCreateTask}
+      />
       <aside className="archive">
         <h2>Архив</h2>
         {archivedTasks.length === 0 ? (

--- a/src/components/Column.tsx
+++ b/src/components/Column.tsx
@@ -1,27 +1,17 @@
 import TaskCard from './TaskCard';
-import { CATEGORIES, useTaskBoard } from '../hooks/useTaskBoard';
-import type { Task, TaskCategory, TaskStatus } from '../types';
+import { useTaskBoard } from '../hooks/useTaskBoard';
+import type { Task, TaskStatus } from '../types';
 
 interface ColumnProps {
   status: TaskStatus;
   title: string;
   tasks: Task[];
-  draftTitle: string;
-  draftCategory: TaskCategory;
-  onDraftTitleChange: (value: string) => void;
-  onDraftCategoryChange: (value: TaskCategory) => void;
-  onCreateTask: () => void;
 }
 
 const Column = ({
   status,
   title,
-  tasks,
-  draftTitle,
-  draftCategory,
-  onDraftTitleChange,
-  onDraftCategoryChange,
-  onCreateTask
+  tasks
 }: ColumnProps) => {
   const { moveTask, updateTask, deleteTask, archiveTask } = useTaskBoard();
 
@@ -31,27 +21,6 @@ const Column = ({
         <h2>{title}</h2>
         <span className="column-count">{tasks.length}</span>
       </header>
-      <div className="column-create">
-        <input
-          type="text"
-          value={draftTitle}
-          placeholder="Название задачи"
-          onChange={(event) => onDraftTitleChange(event.target.value)}
-        />
-        <select
-          value={draftCategory}
-          onChange={(event) => onDraftCategoryChange(event.target.value as TaskCategory)}
-        >
-          {CATEGORIES.map((category) => (
-            <option key={category.id} value={category.id}>
-              {category.label}
-            </option>
-          ))}
-        </select>
-        <button type="button" className="create-button" onClick={onCreateTask}>
-          Добавить
-        </button>
-      </div>
       <div className="column-content">
         {tasks.map((task) => (
           <TaskCard

--- a/src/components/TaskModal.tsx
+++ b/src/components/TaskModal.tsx
@@ -1,0 +1,108 @@
+import { FormEvent, useEffect, useState } from 'react';
+import { CATEGORIES } from '../hooks/useTaskBoard';
+import type { TaskCategory } from '../types';
+
+interface TaskModalProps {
+  isOpen: boolean;
+  onClose: () => void;
+  onCreate: (input: { title: string; category: TaskCategory; content: string }) => void;
+}
+
+const DEFAULT_CONTENT = '<p>Нажмите, чтобы отредактировать описание задачи.</p>';
+
+const TaskModal = ({ isOpen, onClose, onCreate }: TaskModalProps) => {
+  const [title, setTitle] = useState('');
+  const [category, setCategory] = useState<TaskCategory>('development');
+  const [content, setContent] = useState(DEFAULT_CONTENT);
+
+  useEffect(() => {
+    if (isOpen) {
+      setTitle('');
+      setCategory('development');
+      setContent(DEFAULT_CONTENT);
+    }
+  }, [isOpen]);
+
+  const handleSubmit = (event: FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+    const trimmedTitle = title.trim();
+
+    if (!trimmedTitle) {
+      return;
+    }
+
+    const normalizedContent = content.trim() ? content : DEFAULT_CONTENT;
+
+    onCreate({
+      title: trimmedTitle,
+      category,
+      content: normalizedContent
+    });
+  };
+
+  if (!isOpen) {
+    return null;
+  }
+
+  return (
+    <div className="modal-overlay" onClick={onClose}>
+      <div
+        className="modal"
+        role="dialog"
+        aria-modal="true"
+        aria-labelledby="create-task-title"
+        onClick={(event) => event.stopPropagation()}
+      >
+        <header className="modal-header">
+          <h2 id="create-task-title">Новая задача</h2>
+          <button type="button" className="modal-close" aria-label="Закрыть" onClick={onClose}>
+            ×
+          </button>
+        </header>
+        <form className="modal-form" onSubmit={handleSubmit}>
+          <label className="field">
+            <span>Название</span>
+            <input
+              type="text"
+              value={title}
+              onChange={(event) => setTitle(event.target.value)}
+              placeholder="Например, подготовить презентацию"
+              autoFocus
+            />
+          </label>
+          <label className="field">
+            <span>Категория</span>
+            <select
+              value={category}
+              onChange={(event) => setCategory(event.target.value as TaskCategory)}
+            >
+              {CATEGORIES.map((option) => (
+                <option key={option.id} value={option.id}>
+                  {option.label}
+                </option>
+              ))}
+            </select>
+          </label>
+          <label className="field">
+            <span>Описание</span>
+            <textarea
+              rows={4}
+              value={content}
+              onChange={(event) => setContent(event.target.value)}
+            />
+          </label>
+          <div className="modal-actions">
+            <button type="button" className="modal-cancel" onClick={onClose}>
+              Отмена
+            </button>
+            <button type="submit" className="modal-submit">
+              Создать
+            </button>
+          </div>
+        </form>
+      </div>
+    </div>
+  );
+};
+
+export default TaskModal;

--- a/src/styles.css
+++ b/src/styles.css
@@ -62,34 +62,6 @@ body {
   font-size: 0.875rem;
 }
 
-.column-create {
-  display: grid;
-  grid-template-columns: 1fr;
-  gap: 0.5rem;
-}
-
-.column-create input,
-.column-create select {
-  padding: 0.5rem 0.75rem;
-  border-radius: 0.5rem;
-  border: 1px solid #cbd5f5;
-  font-size: 0.95rem;
-}
-
-.create-button {
-  background: #6366f1;
-  border: none;
-  color: #fff;
-  border-radius: 0.5rem;
-  padding: 0.5rem 0.75rem;
-  font-weight: 600;
-  cursor: pointer;
-}
-
-.create-button:hover {
-  background: #4f46e5;
-}
-
 .column-content {
   display: flex;
   flex-direction: column;
@@ -180,10 +152,16 @@ body {
 }
 
 .field input,
-.field select {
+.field select,
+.field textarea {
   padding: 0.5rem 0.75rem;
   border-radius: 0.5rem;
   border: 1px solid #cbd5f5;
+}
+
+.field textarea {
+  resize: vertical;
+  min-height: 140px;
 }
 
 .task-card__editor-actions {
@@ -350,6 +328,104 @@ body {
 
 .archive-item--support {
   border-left: 4px solid #22c55e;
+}
+
+.board-create-fab {
+  position: fixed;
+  bottom: 2rem;
+  right: 2rem;
+  width: 3.5rem;
+  height: 3.5rem;
+  border-radius: 50%;
+  border: none;
+  background: linear-gradient(135deg, #6366f1, #22d3ee);
+  color: #fff;
+  font-size: 2rem;
+  line-height: 1;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  box-shadow: 0 12px 32px rgba(15, 23, 42, 0.2);
+  cursor: pointer;
+  transition: transform 0.2s ease, box-shadow 0.2s ease;
+}
+
+.board-create-fab:hover {
+  transform: translateY(-2px);
+  box-shadow: 0 16px 40px rgba(15, 23, 42, 0.24);
+}
+
+.modal-overlay {
+  position: fixed;
+  inset: 0;
+  background: rgba(15, 23, 42, 0.45);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 1.5rem;
+  z-index: 1000;
+}
+
+.modal {
+  background: #fff;
+  border-radius: 1rem;
+  max-width: 520px;
+  width: 100%;
+  padding: 1.5rem;
+  box-shadow: 0 24px 48px rgba(15, 23, 42, 0.25);
+  display: flex;
+  flex-direction: column;
+  gap: 1.25rem;
+}
+
+.modal-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  gap: 1rem;
+}
+
+.modal-close {
+  background: transparent;
+  border: none;
+  color: #64748b;
+  font-size: 1.5rem;
+  cursor: pointer;
+}
+
+.modal-form {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+
+.modal-actions {
+  display: flex;
+  justify-content: flex-end;
+  gap: 0.75rem;
+}
+
+.modal-cancel,
+.modal-submit {
+  border: none;
+  border-radius: 0.5rem;
+  padding: 0.6rem 1.25rem;
+  font-weight: 600;
+  cursor: pointer;
+}
+
+.modal-cancel {
+  background: #e2e8f0;
+  color: #1f2933;
+}
+
+.modal-submit {
+  background: #6366f1;
+  color: #fff;
+}
+
+.modal-submit:hover {
+  background: #4f46e5;
 }
 
 .task-card--design {


### PR DESCRIPTION
## Summary
- remove per-column draft creation controls in Column and Board
- add a floating global "+" button and task creation modal with default "new" status
- update styles and board tests for the modal-driven workflow

## Testing
- npm test -- --run

------
https://chatgpt.com/codex/tasks/task_e_68dea509117483259231ab7ed34b009d