### PR TITLE
feat: make task placeholder interactive

### DIFF
--- a/src/__tests__/TaskCardPlaceholder.test.tsx
+++ b/src/__tests__/TaskCardPlaceholder.test.tsx
@@ -1,0 +1,72 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { cleanup, render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import TaskCard from '../components/TaskCard';
+import { TASK_PLACEHOLDER_CONTENT } from '../constants/taskContent';
+import type { Task } from '../types';
+
+vi.mock('../components/TaskEditModal', () => ({
+  default: ({ isOpen }: { isOpen: boolean }) =>
+    isOpen ? (
+      <div role="dialog" aria-label="Редактирование задачи">
+        Редактирование задачи
+      </div>
+    ) : null
+}));
+
+vi.mock('../components/TimerBar', () => ({
+  default: () => null
+}));
+
+const baseTask: Task = {
+  id: 'task-1',
+  title: 'Тестовая задача',
+  content: TASK_PLACEHOLDER_CONTENT,
+  status: 'new',
+  category: 'development',
+  archived: false
+};
+
+afterEach(() => {
+  cleanup();
+});
+
+describe('TaskCard placeholder behaviour', () => {
+  it('opens the edit modal when clicking the placeholder content', async () => {
+    const user = userEvent.setup();
+
+    render(
+      <TaskCard
+        task={baseTask}
+        onMove={vi.fn()}
+        onUpdate={vi.fn()}
+        onDelete={vi.fn()}
+        onArchive={vi.fn()}
+      />
+    );
+
+    const placeholder = screen.getByRole('button', { name: 'Добавить описание задачи' });
+    await user.click(placeholder);
+
+    expect(screen.getByRole('dialog', { name: 'Редактирование задачи' })).toBeInTheDocument();
+  });
+
+  it('does not interfere with existing descriptions', async () => {
+    const user = userEvent.setup();
+
+    render(
+      <TaskCard
+        task={{ ...baseTask, content: '<p>Описание заполнено</p>' }}
+        onMove={vi.fn()}
+        onUpdate={vi.fn()}
+        onDelete={vi.fn()}
+        onArchive={vi.fn()}
+      />
+    );
+
+    const content = screen.getByText('Описание заполнено');
+    await user.click(content);
+
+    expect(screen.queryByRole('dialog', { name: 'Редактирование задачи' })).not.toBeInTheDocument();
+  });
+});

--- a/src/components/TaskCard.tsx
+++ b/src/components/TaskCard.tsx
@@ -1,7 +1,9 @@
 import { useMemo, useRef, useState } from 'react';
+import type { KeyboardEvent } from 'react';
 import TimerBar from './TimerBar';
 import TaskEditModal from './TaskEditModal';
 import { CATEGORIES, STATUSES } from '../hooks/useTaskBoard';
+import { TASK_PLACEHOLDER_CONTENT } from '../constants/taskContent';
 import type { Task, TaskStatus, TaskUpdate } from '../types';
 
 interface TaskCardProps {
@@ -36,6 +38,19 @@ const TaskCard = ({ task, onMove, onUpdate, onDelete, onArchive }: TaskCardProps
     onArchive(task.id);
   };
 
+  const handleOpenModal = () => {
+    setIsModalOpen(true);
+  };
+
+  const handlePlaceholderKeyDown = (event: KeyboardEvent<HTMLElement>) => {
+    if (event.key === 'Enter' || event.key === ' ') {
+      event.preventDefault();
+      handleOpenModal();
+    }
+  };
+
+  const isPlaceholder = task.content === TASK_PLACEHOLDER_CONTENT;
+
   return (
     <article ref={cardRef} className={`task-card task-card--${task.category}`}>
       <header className="task-card__header">
@@ -56,7 +71,7 @@ const TaskCard = ({ task, onMove, onUpdate, onDelete, onArchive }: TaskCardProps
               →
             </button>
           )}
-          <button type="button" onClick={() => setIsModalOpen(true)}>
+          <button type="button" onClick={handleOpenModal}>
             Редактировать
           </button>
           <button type="button" className="danger" onClick={handleDelete}>
@@ -67,7 +82,15 @@ const TaskCard = ({ task, onMove, onUpdate, onDelete, onArchive }: TaskCardProps
           </button>
         </div>
       </header>
-      <section className="task-card__content" dangerouslySetInnerHTML={{ __html: task.content }} />
+      <section
+        className={`task-card__content${isPlaceholder ? ' task-card__content--placeholder' : ''}`}
+        dangerouslySetInnerHTML={{ __html: task.content }}
+        onClick={isPlaceholder ? handleOpenModal : undefined}
+        onKeyDown={isPlaceholder ? handlePlaceholderKeyDown : undefined}
+        role={isPlaceholder ? 'button' : undefined}
+        tabIndex={isPlaceholder ? 0 : undefined}
+        aria-label={isPlaceholder ? 'Добавить описание задачи' : undefined}
+      />
       {task.timer && <TimerBar timer={task.timer} />}
       <TaskEditModal
         task={task}

--- a/src/components/TaskModal.tsx
+++ b/src/components/TaskModal.tsx
@@ -1,5 +1,6 @@
 import { FormEvent, useEffect, useState } from 'react';
 import { CATEGORIES } from '../hooks/useTaskBoard';
+import { TASK_PLACEHOLDER_CONTENT } from '../constants/taskContent';
 import type { TaskCategory } from '../types';
 
 interface TaskModalProps {
@@ -8,18 +9,16 @@ interface TaskModalProps {
   onCreate: (input: { title: string; category: TaskCategory; content: string }) => void;
 }
 
-const DEFAULT_CONTENT = '<p>Нажмите, чтобы отредактировать описание задачи.</p>';
-
 const TaskModal = ({ isOpen, onClose, onCreate }: TaskModalProps) => {
   const [title, setTitle] = useState('');
   const [category, setCategory] = useState<TaskCategory>('development');
-  const [content, setContent] = useState(DEFAULT_CONTENT);
+  const [content, setContent] = useState(TASK_PLACEHOLDER_CONTENT);
 
   useEffect(() => {
     if (isOpen) {
       setTitle('');
       setCategory('development');
-      setContent(DEFAULT_CONTENT);
+      setContent(TASK_PLACEHOLDER_CONTENT);
     }
   }, [isOpen]);
 
@@ -31,7 +30,7 @@ const TaskModal = ({ isOpen, onClose, onCreate }: TaskModalProps) => {
       return;
     }
 
-    const normalizedContent = content.trim() ? content : DEFAULT_CONTENT;
+    const normalizedContent = content.trim() ? content : TASK_PLACEHOLDER_CONTENT;
 
     onCreate({
       title: trimmedTitle,

--- a/src/constants/taskContent.ts
+++ b/src/constants/taskContent.ts
@@ -1,0 +1,1 @@
+export const TASK_PLACEHOLDER_CONTENT = '<p>Нажмите, чтобы отредактировать описание задачи.</p>';

--- a/src/styles.css
+++ b/src/styles.css
@@ -132,6 +132,18 @@ body {
   padding: 0.75rem;
   border: 1px solid #e2e8f0;
   min-height: 120px;
+  transition: border-color 0.2s ease, box-shadow 0.2s ease;
+}
+
+.task-card__content--placeholder {
+  cursor: pointer;
+}
+
+.task-card__content--placeholder:hover,
+.task-card__content--placeholder:focus-visible {
+  border-style: dashed;
+  border-color: #94a3b8;
+  box-shadow: 0 0 0 2px rgba(148, 163, 184, 0.25);
 }
 
 .task-card__editor {


### PR DESCRIPTION
## Summary
- extract the task description placeholder HTML into a shared constant
- reuse the placeholder in the creation modal and make task cards open editing when it is shown
- highlight placeholder content with hover styles to indicate it is clickable

## Testing
- npm test


------
https://chatgpt.com/codex/tasks/task_e_68deac563b188325b432156b76822891