### PR TITLE
Add settings modal for managing categories and theme

### DIFF
--- a/src/__tests__/Settings.test.tsx
+++ b/src/__tests__/Settings.test.tsx
@@ -1,0 +1,80 @@
+import { beforeEach, describe, expect, it } from 'vitest';
+import { render, screen, within, cleanup, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import App from '../App';
+
+const openSettings = async (user: ReturnType<typeof userEvent.setup>) => {
+  await user.click(screen.getByRole('button', { name: 'Открыть параметры' }));
+  return screen.getByRole('dialog', { name: 'Параметры' });
+};
+
+describe('Панель параметров', () => {
+  beforeEach(() => {
+    window.localStorage.clear();
+    cleanup();
+  });
+
+  it('позволяет создавать и удалять категории с сохранением задач', async () => {
+    const user = userEvent.setup();
+    render(<App />);
+
+    const settings = await openSettings(user);
+
+    const categoryInput = within(settings).getByLabelText('Новая категория');
+    await user.type(categoryInput, 'Аналитика');
+    await user.click(within(settings).getByRole('button', { name: 'Добавить' }));
+
+    expect(within(settings).getByText('Аналитика')).toBeInTheDocument();
+
+    await user.click(within(settings).getByRole('button', { name: 'Готово' }));
+
+    await user.click(screen.getByRole('button', { name: 'Создать задачу' }));
+    const taskModal = screen.getByRole('dialog', { name: 'Новая задача' });
+    const titleInput = within(taskModal).getByLabelText('Название');
+    await user.type(titleInput, 'Подготовить аналитический отчёт');
+    const categorySelect = within(taskModal).getByLabelText('Категория');
+    await user.selectOptions(categorySelect, within(taskModal).getByRole('option', { name: 'Аналитика' }));
+    await user.click(within(taskModal).getByRole('button', { name: 'Создать' }));
+
+    const cardHeading = await screen.findByRole('heading', { name: 'Подготовить аналитический отчёт' });
+    const card = cardHeading.closest('article') as HTMLElement;
+    expect(within(card).getByText('Аналитика')).toBeVisible();
+
+    const settingsAgain = await openSettings(user);
+    const analyticsItem = within(settingsAgain).getByText('Аналитика').closest('li') as HTMLElement;
+    await user.click(within(analyticsItem).getByRole('button', { name: 'Удалить' }));
+
+    expect(within(settingsAgain).queryByText('Аналитика')).toBeNull();
+
+    await user.click(within(settingsAgain).getByRole('button', { name: 'Готово' }));
+
+    expect(within(card).getByText('Дизайн')).toBeVisible();
+
+    await user.click(screen.getByRole('button', { name: 'Создать задачу' }));
+    const newModal = screen.getByRole('dialog', { name: 'Новая задача' });
+    expect(within(newModal).queryByRole('option', { name: 'Аналитика' })).toBeNull();
+  });
+
+  it('переключает и сохраняет тему интерфейса', async () => {
+    const user = userEvent.setup();
+    const { unmount } = render(<App />);
+
+    expect(document.documentElement.classList.contains('dark')).toBe(false);
+
+    const settings = await openSettings(user);
+    await user.click(within(settings).getByLabelText('Тёмная'));
+
+    expect(document.documentElement.classList.contains('dark')).toBe(true);
+    expect(document.documentElement.style.getPropertyValue('color-scheme')).toBe('dark');
+    expect(window.localStorage.getItem('pintaker.theme')).toBe('dark');
+
+    await user.click(within(settings).getByRole('button', { name: 'Готово' }));
+
+    unmount();
+    render(<App />);
+
+    await waitFor(() => {
+      expect(document.documentElement.classList.contains('dark')).toBe(true);
+    });
+  });
+});

--- a/src/components/Board.tsx
+++ b/src/components/Board.tsx
@@ -1,12 +1,14 @@
 import { useState } from 'react';
 import Column from './Column';
 import TaskModal from './TaskModal';
+import SettingsModal from './SettingsModal';
 import { useTaskBoard, STATUSES } from '../hooks/useTaskBoard';
 import type { TaskCategory } from '../types';
 
 const Board = () => {
   const { activeTasks, archivedTasks, addTask, restoreTask } = useTaskBoard();
   const [isModalOpen, setModalOpen] = useState(false);
+  const [isSettingsOpen, setSettingsOpen] = useState(false);
 
   const handleCreateTask = ({
     title,
@@ -41,6 +43,14 @@ const Board = () => {
       </div>
       <button
         type="button"
+        className="board-settings-fab"
+        aria-label="Открыть параметры"
+        onClick={() => setSettingsOpen(true)}
+      >
+        ⚙
+      </button>
+      <button
+        type="button"
         className="board-create-fab"
         aria-label="Создать задачу"
         onClick={() => setModalOpen(true)}
@@ -52,6 +62,7 @@ const Board = () => {
         onClose={() => setModalOpen(false)}
         onCreate={handleCreateTask}
       />
+      <SettingsModal isOpen={isSettingsOpen} onClose={() => setSettingsOpen(false)} />
       <aside className="archive">
         <h2>Архив</h2>
         {archivedTasks.length === 0 ? (

--- a/src/components/SettingsModal.tsx
+++ b/src/components/SettingsModal.tsx
@@ -1,0 +1,153 @@
+import { FormEvent, MouseEvent, useEffect, useState } from 'react';
+import { ThemeMode, useTaskBoard } from '../hooks/useTaskBoard';
+
+interface SettingsModalProps {
+  isOpen: boolean;
+  onClose: () => void;
+}
+
+const SettingsModal = ({ isOpen, onClose }: SettingsModalProps) => {
+  const { categories, addCategory, removeCategory, theme, setTheme } = useTaskBoard();
+  const [newCategory, setNewCategory] = useState('');
+  const [error, setError] = useState('');
+
+  useEffect(() => {
+    if (isOpen) {
+      setNewCategory('');
+      setError('');
+    }
+  }, [isOpen]);
+
+  if (!isOpen) {
+    return null;
+  }
+
+  const handleSubmit = (event: FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+    const created = addCategory(newCategory);
+    if (!created) {
+      setError('Введите название категории.');
+      return;
+    }
+
+    setNewCategory('');
+    setError('');
+  };
+
+  const handleRemove = (categoryId: string) => {
+    const removed = removeCategory(categoryId);
+    if (!removed) {
+      setError('Нельзя удалить последнюю категорию.');
+    } else {
+      setError('');
+    }
+  };
+
+  const handleOverlayClick = (event: MouseEvent<HTMLDivElement>) => {
+    if (event.target === event.currentTarget) {
+      onClose();
+    }
+  };
+
+  const handleThemeChange = (mode: ThemeMode) => {
+    setTheme(mode);
+  };
+
+  return (
+    <div className="modal-overlay" role="presentation" onClick={handleOverlayClick}>
+      <div
+        className="modal settings-modal"
+        role="dialog"
+        aria-modal="true"
+        aria-labelledby="settings-modal-title"
+        onClick={(event) => event.stopPropagation()}
+      >
+        <header className="modal-header">
+          <h2 id="settings-modal-title">Параметры</h2>
+          <button type="button" className="modal-close" aria-label="Закрыть" onClick={onClose}>
+            ×
+          </button>
+        </header>
+
+        <section className="settings-section">
+          <h3>Категории</h3>
+          <p className="settings-description">
+            Создайте собственные категории или удалите лишние. Задачи с удалённой категорией
+            получат первую доступную из списка.
+          </p>
+          <form className="settings-category-form" onSubmit={handleSubmit}>
+            <label className="field">
+              <span>Новая категория</span>
+              <input
+                type="text"
+                value={newCategory}
+                onChange={(event) => setNewCategory(event.target.value)}
+                placeholder="Например, Аналитика"
+              />
+            </label>
+            <button type="submit" className="modal-submit">
+              Добавить
+            </button>
+          </form>
+          <ul className="settings-category-list">
+            {categories.map((category) => (
+              <li key={category.id} className="settings-category-item">
+                <div>
+                  <strong>{category.label}</strong>
+                  <span className="settings-category-id">{category.id}</span>
+                </div>
+                <button
+                  type="button"
+                  onClick={() => handleRemove(category.id)}
+                  disabled={categories.length <= 1}
+                >
+                  Удалить
+                </button>
+              </li>
+            ))}
+          </ul>
+        </section>
+
+        <section className="settings-section">
+          <h3>Тема</h3>
+          <p className="settings-description">
+            Переключайтесь между светлой и тёмной темой. Настройки сохраняются в этом браузере.
+          </p>
+          <fieldset className="settings-theme" aria-label="Выбор темы">
+            <legend className="sr-only">Тема оформления</legend>
+            <label>
+              <input
+                type="radio"
+                name="color-theme"
+                value="light"
+                checked={theme === 'light'}
+                onChange={() => handleThemeChange('light')}
+              />
+              Светлая
+            </label>
+            <label>
+              <input
+                type="radio"
+                name="color-theme"
+                value="dark"
+                checked={theme === 'dark'}
+                onChange={() => handleThemeChange('dark')}
+              />
+              Тёмная
+            </label>
+          </fieldset>
+        </section>
+
+        {error && <p className="settings-error" role="alert">{error}</p>}
+
+        <footer className="modal-footer">
+          <button type="button" className="primary" onClick={onClose}>
+            Готово
+          </button>
+        </footer>
+      </div>
+    </div>
+  );
+};
+
+export default SettingsModal;

--- a/src/components/TaskCard.tsx
+++ b/src/components/TaskCard.tsx
@@ -1,7 +1,7 @@
 import { useMemo, useRef, useState } from 'react';
 import TimerBar from './TimerBar';
 import TaskEditModal from './TaskEditModal';
-import { CATEGORIES, STATUSES } from '../hooks/useTaskBoard';
+import { STATUSES, useTaskBoard } from '../hooks/useTaskBoard';
 import type { Task, TaskStatus, TaskUpdate } from '../types';
 
 interface TaskCardProps {
@@ -15,6 +15,7 @@ interface TaskCardProps {
 const statusOrder: TaskStatus[] = STATUSES.map((status) => status.id);
 
 const TaskCard = ({ task, onMove, onUpdate, onDelete, onArchive }: TaskCardProps) => {
+  const { categories } = useTaskBoard();
   const [isModalOpen, setIsModalOpen] = useState(false);
   const cardRef = useRef<HTMLElement | null>(null);
 
@@ -36,12 +37,16 @@ const TaskCard = ({ task, onMove, onUpdate, onDelete, onArchive }: TaskCardProps
     onArchive(task.id);
   };
 
+  const categoryLabel = useMemo(() => {
+    return categories.find((item) => item.id === task.category)?.label ?? task.category;
+  }, [categories, task.category]);
+
   return (
     <article ref={cardRef} className={`task-card task-card--${task.category}`}>
       <header className="task-card__header">
         <div className="task-card__title">
           <span className="task-card__category">
-            {CATEGORIES.find((item) => item.id === task.category)?.label ?? task.category}
+            {categoryLabel}
           </span>
           <h3>{task.title}</h3>
         </div>

--- a/src/components/TaskEditModal.tsx
+++ b/src/components/TaskEditModal.tsx
@@ -1,7 +1,7 @@
 import { type MouseEvent, useEffect, useMemo, useState } from 'react';
 import { createPortal } from 'react-dom';
 import RichTextEditor from './RichTextEditor';
-import { CATEGORIES, STATUSES } from '../hooks/useTaskBoard';
+import { STATUSES, useTaskBoard } from '../hooks/useTaskBoard';
 import type { Task, TaskCategory, TaskStatus, TaskTimer, TaskUpdate } from '../types';
 
 interface TaskEditModalProps {
@@ -25,6 +25,7 @@ const TaskEditModal = ({
   onArchive,
   container
 }: TaskEditModalProps) => {
+  const { categories } = useTaskBoard();
   const [title, setTitle] = useState(task.title);
   const [category, setCategory] = useState<TaskCategory>(task.category);
   const [content, setContent] = useState(task.content);
@@ -40,6 +41,16 @@ const TaskEditModal = ({
     setContent(task.content);
     setDurationMinutes(task.timer?.durationMinutes ?? 30);
   }, [isOpen, task]);
+
+  useEffect(() => {
+    if (!isOpen) {
+      return;
+    }
+
+    if (!categories.some((item) => item.id === category)) {
+      setCategory(categories[0]?.id ?? category);
+    }
+  }, [isOpen, categories, category]);
 
   useEffect(() => {
     if (!isOpen) {
@@ -107,7 +118,7 @@ const TaskEditModal = ({
   const modalContent = (
     <div className="modal-overlay" role="presentation" onClick={handleOverlayClick}>
       <div
-        className="modal"
+        className="modal modal--wide"
         role="dialog"
         aria-modal="true"
         aria-labelledby={`task-modal-${task.id}`}
@@ -147,7 +158,7 @@ const TaskEditModal = ({
           <label className="field">
             <span>Категория</span>
             <select value={category} onChange={(event) => setCategory(event.target.value as TaskCategory)}>
-              {CATEGORIES.map((item) => (
+              {categories.map((item) => (
                 <option key={item.id} value={item.id}>
                   {item.label}
                 </option>

--- a/src/hooks/useTaskBoard.tsx
+++ b/src/hooks/useTaskBoard.tsx
@@ -1,7 +1,18 @@
-import React, { createContext, useContext, useMemo, useState } from 'react';
-import { Task, TaskCategory, TaskStatus, TaskTimer, TaskUpdate } from '../types';
+import React, { createContext, useContext, useEffect, useMemo, useState } from 'react';
+import {
+  Task,
+  TaskCategory,
+  TaskCategoryOption,
+  TaskStatus,
+  TaskTimer,
+  TaskUpdate
+} from '../types';
 
 const STORAGE_KEY = 'pintaker.tasks';
+const CATEGORY_STORAGE_KEY = 'pintaker.categories';
+const THEME_STORAGE_KEY = 'pintaker.theme';
+
+export type ThemeMode = 'light' | 'dark';
 
 export const STATUSES: { id: TaskStatus; label: string }[] = [
   { id: 'new', label: 'Новый' },
@@ -9,7 +20,7 @@ export const STATUSES: { id: TaskStatus; label: string }[] = [
   { id: 'done', label: 'Выполнено' }
 ];
 
-export const CATEGORIES: { id: TaskCategory; label: string }[] = [
+const DEFAULT_CATEGORIES: TaskCategoryOption[] = [
   { id: 'design', label: 'Дизайн' },
   { id: 'development', label: 'Разработка' },
   { id: 'research', label: 'Исследование' },
@@ -21,6 +32,12 @@ interface TaskBoardContextValue {
   tasks: Task[];
   activeTasks: Task[];
   archivedTasks: Task[];
+  categories: TaskCategoryOption[];
+  addCategory: (label: string) => TaskCategoryOption | null;
+  removeCategory: (id: TaskCategory) => boolean;
+  theme: ThemeMode;
+  setTheme: (theme: ThemeMode) => void;
+  toggleTheme: () => void;
   addTask: (input: {
     title: string;
     content?: string;
@@ -62,6 +79,65 @@ const writeToStorage = (tasks: Task[]) => {
   window.localStorage.setItem(STORAGE_KEY, JSON.stringify(tasks));
 };
 
+const readCategoriesFromStorage = (): TaskCategoryOption[] => {
+  if (typeof window === 'undefined') {
+    return DEFAULT_CATEGORIES;
+  }
+
+  try {
+    const raw = window.localStorage.getItem(CATEGORY_STORAGE_KEY);
+    if (!raw) {
+      return DEFAULT_CATEGORIES;
+    }
+    const parsed = JSON.parse(raw) as TaskCategoryOption[];
+    if (!Array.isArray(parsed)) {
+      return DEFAULT_CATEGORIES;
+    }
+    const sanitized = parsed.filter(
+      (item): item is TaskCategoryOption =>
+        typeof item?.id === 'string' && typeof item?.label === 'string'
+    );
+    return sanitized.length > 0 ? sanitized : DEFAULT_CATEGORIES;
+  } catch (error) {
+    console.error('Не удалось загрузить категории', error);
+    return DEFAULT_CATEGORIES;
+  }
+};
+
+const writeCategoriesToStorage = (categories: TaskCategoryOption[]) => {
+  if (typeof window === 'undefined') {
+    return;
+  }
+  window.localStorage.setItem(CATEGORY_STORAGE_KEY, JSON.stringify(categories));
+};
+
+const readThemeFromStorage = (): ThemeMode => {
+  if (typeof window === 'undefined') {
+    return 'light';
+  }
+
+  const stored = window.localStorage.getItem(THEME_STORAGE_KEY);
+  return stored === 'dark' ? 'dark' : 'light';
+};
+
+const writeThemeToStorage = (theme: ThemeMode) => {
+  if (typeof window === 'undefined') {
+    return;
+  }
+  window.localStorage.setItem(THEME_STORAGE_KEY, theme);
+};
+
+const applyTheme = (theme: ThemeMode) => {
+  if (typeof document === 'undefined') {
+    return;
+  }
+
+  const root = document.documentElement;
+  root.style.setProperty('color-scheme', theme);
+  root.classList.remove('light', 'dark');
+  root.classList.add(theme);
+};
+
 const generateId = () => {
   if (typeof crypto !== 'undefined' && 'randomUUID' in crypto) {
     return crypto.randomUUID();
@@ -71,10 +147,44 @@ const generateId = () => {
 
 export const TaskBoardProvider: React.FC<React.PropsWithChildren> = ({ children }) => {
   const [tasks, setTasks] = useState<Task[]>(() => readFromStorage());
+  const [categories, setCategories] = useState<TaskCategoryOption[]>(() =>
+    readCategoriesFromStorage()
+  );
+  const [theme, setThemeState] = useState<ThemeMode>(() => readThemeFromStorage());
+
+  useEffect(() => {
+    writeCategoriesToStorage(categories);
+  }, [categories]);
+
+  useEffect(() => {
+    applyTheme(theme);
+    writeThemeToStorage(theme);
+  }, [theme]);
 
   const persist = (nextTasks: Task[]) => {
     setTasks(nextTasks);
     writeToStorage(nextTasks);
+  };
+
+  const ensureCategory = (category: TaskCategory): TaskCategory => {
+    if (categories.some((item) => item.id === category)) {
+      return category;
+    }
+    return categories[0]?.id ?? category;
+  };
+
+  const createCategoryId = (label: string) => {
+    const normalized = label.toLowerCase().trim().normalize('NFD').replace(/[\u0300-\u036f]/g, '');
+    const base = normalized.replace(/[^a-z0-9]+/g, '-').replace(/^-+|-+$/g, '') || `category-${generateId()}`;
+
+    let candidate = base;
+    let index = 1;
+
+    while (categories.some((item) => item.id === candidate)) {
+      candidate = `${base}-${index++}`;
+    }
+
+    return candidate;
   };
 
   const addTask: TaskBoardContextValue['addTask'] = ({
@@ -89,7 +199,7 @@ export const TaskBoardProvider: React.FC<React.PropsWithChildren> = ({ children 
       title,
       content,
       status,
-      category,
+      category: ensureCategory(category),
       archived: false,
       timer: timer ?? undefined
     };
@@ -103,6 +213,8 @@ export const TaskBoardProvider: React.FC<React.PropsWithChildren> = ({ children 
           ? {
               ...task,
               ...updates,
+              category:
+                updates.category !== undefined ? ensureCategory(updates.category) : task.category,
               timer: updates.timer === null ? undefined : updates.timer ?? task.timer
             }
           : task
@@ -126,11 +238,61 @@ export const TaskBoardProvider: React.FC<React.PropsWithChildren> = ({ children 
     updateTask(id, { status });
   };
 
+  const addCategory: TaskBoardContextValue['addCategory'] = (label) => {
+    const trimmed = label.trim();
+    if (!trimmed) {
+      return null;
+    }
+
+    const newCategory: TaskCategoryOption = {
+      id: createCategoryId(trimmed),
+      label: trimmed
+    };
+
+    setCategories([...categories, newCategory]);
+    return newCategory;
+  };
+
+  const removeCategory: TaskBoardContextValue['removeCategory'] = (id) => {
+    if (categories.length <= 1) {
+      return false;
+    }
+
+    const exists = categories.some((item) => item.id === id);
+    if (!exists) {
+      return false;
+    }
+
+    const nextCategories = categories.filter((item) => item.id !== id);
+    setCategories(nextCategories);
+
+    const fallback = nextCategories[0]?.id;
+    if (fallback) {
+      persist(tasks.map((task) => (task.category === id ? { ...task, category: fallback } : task)));
+    }
+
+    return true;
+  };
+
+  const setTheme: TaskBoardContextValue['setTheme'] = (nextTheme) => {
+    setThemeState(nextTheme);
+  };
+
+  const toggleTheme: TaskBoardContextValue['toggleTheme'] = () => {
+    setThemeState((prev) => (prev === 'light' ? 'dark' : 'light'));
+  };
+
   const value = useMemo<TaskBoardContextValue>(
     () => ({
       tasks,
       activeTasks: tasks.filter((task) => !task.archived),
       archivedTasks: tasks.filter((task) => task.archived),
+      categories,
+      addCategory,
+      removeCategory,
+      theme,
+      setTheme,
+      toggleTheme,
       addTask,
       updateTask,
       deleteTask,
@@ -138,7 +300,7 @@ export const TaskBoardProvider: React.FC<React.PropsWithChildren> = ({ children 
       moveTask,
       restoreTask
     }),
-    [tasks]
+    [tasks, categories, theme]
   );
 
   return <TaskBoardContext.Provider value={value}>{children}</TaskBoardContext.Provider>;

--- a/src/styles.css
+++ b/src/styles.css
@@ -1,12 +1,56 @@
 :root {
   color-scheme: light;
   font-family: 'Inter', system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
-  background: #f4f6fa;
-  color: #1f2933;
+  --background-color: #f4f6fa;
+  --text-color: #1f2933;
+  --surface-color: #ffffff;
+  --surface-muted-color: #f8fafc;
+  --border-color: #e2e8f0;
+  --border-strong-color: #cbd5f5;
+  --muted-color: #64748b;
+  --shadow-soft: 0 8px 24px rgba(15, 23, 42, 0.08);
+  --shadow-strong: 0 24px 48px rgba(15, 23, 42, 0.25);
+  --button-bg: #e2e8f0;
+  --button-hover-bg: #cbd5f5;
+  --danger-bg: #f87171;
+  --danger-hover-bg: #ef4444;
+  --overlay-color: rgba(15, 23, 42, 0.45);
+}
+
+:root.dark {
+  color-scheme: dark;
+  --background-color: #0f172a;
+  --text-color: #e2e8f0;
+  --surface-color: #1e293b;
+  --surface-muted-color: #1f2937;
+  --border-color: #334155;
+  --border-strong-color: #475569;
+  --muted-color: #94a3b8;
+  --shadow-soft: 0 8px 24px rgba(2, 6, 23, 0.5);
+  --shadow-strong: 0 24px 48px rgba(2, 6, 23, 0.65);
+  --button-bg: #334155;
+  --button-hover-bg: #475569;
+  --danger-bg: #f87171;
+  --danger-hover-bg: #dc2626;
+  --overlay-color: rgba(2, 6, 23, 0.7);
 }
 
 body {
   margin: 0;
+  background: var(--background-color);
+  color: var(--text-color);
+}
+
+.sr-only {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border: 0;
 }
 
 .app-shell {
@@ -36,11 +80,12 @@ body {
   grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
 }
 
+
 .column {
-  background: #fff;
+  background: var(--surface-color);
   border-radius: 1rem;
   padding: 1rem;
-  box-shadow: 0 8px 24px rgba(15, 23, 42, 0.08);
+  box-shadow: var(--shadow-soft);
   display: flex;
   flex-direction: column;
   gap: 1rem;
@@ -50,13 +95,13 @@ body {
   display: flex;
   align-items: center;
   justify-content: space-between;
-  border-bottom: 1px solid #e2e8f0;
+  border-bottom: 1px solid var(--border-color);
   padding-bottom: 0.5rem;
 }
 
 .column-count {
-  background: #e2e8f0;
-  color: #0f172a;
+  background: var(--button-bg);
+  color: var(--text-color);
   padding: 0.25rem 0.75rem;
   border-radius: 999px;
   font-size: 0.875rem;
@@ -69,15 +114,15 @@ body {
 }
 
 .column-empty {
-  color: #64748b;
+  color: var(--muted-color);
   font-size: 0.9rem;
 }
 
 .task-card {
-  background: #f8fafc;
+  background: var(--surface-muted-color);
   border-radius: 0.75rem;
   padding: 0.75rem;
-  border: 1px solid #e2e8f0;
+  border: 1px solid var(--border-color);
   display: flex;
   flex-direction: column;
   gap: 0.75rem;
@@ -100,7 +145,7 @@ body {
   text-transform: uppercase;
   letter-spacing: 0.08em;
   font-weight: 700;
-  color: #475569;
+  color: var(--muted-color);
 }
 
 .task-card__actions {
@@ -110,27 +155,29 @@ body {
 }
 
 .task-card__actions button {
-  background: #e2e8f0;
+  background: var(--button-bg);
+  color: var(--text-color);
   border: none;
   border-radius: 0.5rem;
   padding: 0.35rem 0.6rem;
   cursor: pointer;
+  transition: background 0.2s ease;
 }
 
 .task-card__actions button:hover {
-  background: #cbd5f5;
+  background: var(--button-hover-bg);
 }
 
 .task-card__actions .danger {
-  background: #f87171;
+  background: var(--danger-bg);
   color: #fff;
 }
 
 .task-card__content {
-  background: #fff;
+  background: var(--surface-color);
   border-radius: 0.5rem;
   padding: 0.75rem;
-  border: 1px solid #e2e8f0;
+  border: 1px solid var(--border-color);
   min-height: 120px;
 }
 
@@ -138,10 +185,10 @@ body {
   display: flex;
   flex-direction: column;
   gap: 0.75rem;
-  background: #fff;
+  background: var(--surface-color);
   padding: 0.75rem;
   border-radius: 0.5rem;
-  border: 1px solid #cbd5f5;
+  border: 1px solid var(--border-strong-color);
 }
 
 .field {
@@ -156,7 +203,9 @@ body {
 .field textarea {
   padding: 0.5rem 0.75rem;
   border-radius: 0.5rem;
-  border: 1px solid #cbd5f5;
+  border: 1px solid var(--border-strong-color);
+  background: var(--surface-color);
+  color: var(--text-color);
 }
 
 .field textarea {
@@ -169,6 +218,7 @@ body {
   flex-wrap: wrap;
   gap: 0.5rem;
 }
+
 
 .task-card__editor-actions button {
   background: #6366f1;
@@ -194,7 +244,7 @@ body {
 .modal-overlay {
   position: fixed;
   inset: 0;
-  background: rgba(15, 23, 42, 0.45);
+  background: var(--overlay-color);
   display: flex;
   align-items: center;
   justify-content: center;
@@ -203,14 +253,12 @@ body {
 }
 
 .modal {
-  background: #fff;
+  background: var(--surface-color);
   border-radius: 1rem;
-  width: min(680px, 100%);
-  max-height: 90vh;
-  overflow: hidden;
   display: flex;
   flex-direction: column;
-  box-shadow: 0 24px 48px rgba(15, 23, 42, 0.18);
+  box-shadow: var(--shadow-strong);
+  color: var(--text-color);
 }
 
 .modal-header {
@@ -218,7 +266,7 @@ body {
   justify-content: space-between;
   align-items: center;
   padding: 1.25rem 1.5rem;
-  border-bottom: 1px solid #e2e8f0;
+  border-bottom: 1px solid var(--border-color);
 }
 
 .modal-header h2 {
@@ -232,7 +280,7 @@ body {
   font-size: 1.5rem;
   cursor: pointer;
   line-height: 1;
-  color: #475569;
+  color: var(--muted-color);
 }
 
 .modal-task-meta {
@@ -244,7 +292,7 @@ body {
 
 .modal-task-status {
   font-size: 0.95rem;
-  color: #475569;
+  color: var(--muted-color);
 }
 
 .modal-task-actions {
@@ -254,12 +302,13 @@ body {
 }
 
 .modal-task-actions button {
-  background: #e2e8f0;
+  background: var(--button-bg);
   border: none;
   border-radius: 0.5rem;
   padding: 0.45rem 0.75rem;
   cursor: pointer;
   font-size: 0.9rem;
+  color: var(--text-color);
 }
 
 .modal-body {
@@ -300,7 +349,7 @@ body {
   justify-content: flex-end;
   gap: 0.75rem;
   padding: 1.25rem 1.5rem;
-  border-top: 1px solid #e2e8f0;
+  border-top: 1px solid var(--border-color);
 }
 
 .modal-footer .primary,
@@ -318,12 +367,12 @@ body {
 }
 
 .modal-footer .secondary {
-  background: #e2e8f0;
-  color: #0f172a;
+  background: var(--button-bg);
+  color: var(--text-color);
 }
 
 .modal-footer .secondary:hover {
-  background: #cbd5f5;
+  background: var(--button-hover-bg);
 }
 
 .timer {
@@ -334,11 +383,11 @@ body {
 
 .timer-label {
   font-size: 0.85rem;
-  color: #0f172a;
+  color: var(--text-color);
 }
 
 .timer-bar {
-  background: #e2e8f0;
+  background: var(--button-bg);
   border-radius: 999px;
   overflow: hidden;
   height: 8px;
@@ -366,8 +415,8 @@ body {
 }
 
 .rte-button {
-  border: 1px solid #cbd5f5;
-  background: #f8fafc;
+  border: 1px solid var(--border-strong-color);
+  background: var(--surface-muted-color);
   border-radius: 0.5rem;
   padding: 0.35rem 0.6rem;
   cursor: pointer;
@@ -375,10 +424,11 @@ body {
 
 .rte-editor {
   min-height: 160px;
-  border: 1px solid #cbd5f5;
+  border: 1px solid var(--border-strong-color);
   border-radius: 0.5rem;
   padding: 0.5rem;
-  background: #fff;
+  background: var(--surface-color);
+  color: var(--text-color);
 }
 
 .rte-editor:focus {
@@ -391,16 +441,16 @@ body {
 }
 
 .rte-table td {
-  border: 1px solid #cbd5f5;
+  border: 1px solid var(--border-strong-color);
   min-height: 32px;
   padding: 0.25rem;
 }
 
 .archive {
-  background: #fff;
+  background: var(--surface-color);
   border-radius: 1rem;
   padding: 1rem;
-  box-shadow: 0 8px 24px rgba(15, 23, 42, 0.08);
+  box-shadow: var(--shadow-soft);
   display: flex;
   flex-direction: column;
   gap: 1rem;
@@ -419,8 +469,8 @@ body {
   display: flex;
   justify-content: space-between;
   align-items: center;
-  background: #f8fafc;
-  border: 1px solid #e2e8f0;
+  background: var(--surface-muted-color);
+  border: 1px solid var(--border-color);
   border-radius: 0.75rem;
   padding: 0.5rem 0.75rem;
 }
@@ -428,7 +478,7 @@ body {
 .archive-status {
   display: block;
   font-size: 0.75rem;
-  color: #64748b;
+  color: var(--muted-color);
 }
 
 .archive-restore {
@@ -442,7 +492,7 @@ body {
 
 .archive-hint {
   font-size: 0.85rem;
-  color: #475569;
+  color: var(--muted-color);
 }
 
 .archive-item--design {
@@ -490,42 +540,52 @@ body {
   box-shadow: 0 16px 40px rgba(15, 23, 42, 0.24);
 }
 
-.modal-overlay {
+.board-settings-fab {
   position: fixed;
-  inset: 0;
-  background: rgba(15, 23, 42, 0.45);
+  bottom: 2rem;
+  right: 6.5rem;
+  width: 3.5rem;
+  height: 3.5rem;
+  border-radius: 50%;
+  border: none;
+  background: linear-gradient(135deg, #0ea5e9, #6366f1);
+  color: #fff;
+  font-size: 1.6rem;
+  line-height: 1;
   display: flex;
   align-items: center;
   justify-content: center;
-  padding: 1.5rem;
-  z-index: 1000;
+  box-shadow: 0 12px 32px rgba(15, 23, 42, 0.2);
+  cursor: pointer;
+  transition: transform 0.2s ease, box-shadow 0.2s ease;
 }
 
-.modal {
-  background: #fff;
-  border-radius: 1rem;
+.board-settings-fab:hover {
+  transform: translateY(-2px);
+  box-shadow: 0 16px 40px rgba(15, 23, 42, 0.24);
+}
+
+.modal--wide {
+  width: min(680px, 100%);
+  max-height: 90vh;
+  overflow: hidden;
+}
+
+.modal--compact {
   max-width: 520px;
   width: 100%;
   padding: 1.5rem;
-  box-shadow: 0 24px 48px rgba(15, 23, 42, 0.25);
-  display: flex;
-  flex-direction: column;
   gap: 1.25rem;
 }
 
-.modal-header {
-  display: flex;
-  justify-content: space-between;
-  align-items: center;
+.modal--compact .modal-header {
+  padding: 0;
+  border: none;
   gap: 1rem;
 }
 
-.modal-close {
-  background: transparent;
-  border: none;
-  color: #64748b;
-  font-size: 1.5rem;
-  cursor: pointer;
+.modal--compact .modal-close {
+  color: var(--muted-color);
 }
 
 .modal-form {
@@ -550,8 +610,8 @@ body {
 }
 
 .modal-cancel {
-  background: #e2e8f0;
-  color: #1f2933;
+  background: var(--button-bg);
+  color: var(--text-color);
 }
 
 .modal-submit {
@@ -561,6 +621,114 @@ body {
 
 .modal-submit:hover {
   background: #4f46e5;
+}
+
+.settings-modal {
+  max-width: 640px;
+  width: 100%;
+  padding: 1.75rem;
+  gap: 1.5rem;
+  max-height: 90vh;
+  overflow-y: auto;
+}
+
+.settings-modal .modal-header {
+  padding: 0;
+  border: none;
+}
+
+.settings-modal .modal-footer {
+  padding: 0;
+  border: none;
+}
+
+.settings-section {
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+}
+
+.settings-description {
+  margin: 0;
+  color: var(--muted-color);
+  font-size: 0.9rem;
+}
+
+.settings-category-form {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.75rem;
+  align-items: flex-end;
+}
+
+.settings-category-form .field {
+  flex: 1 1 220px;
+  margin: 0;
+}
+
+.settings-category-list {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+}
+
+.settings-category-item {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  gap: 1rem;
+  background: var(--surface-muted-color);
+  border: 1px solid var(--border-color);
+  border-radius: 0.75rem;
+  padding: 0.5rem 0.75rem;
+}
+
+.settings-category-id {
+  display: block;
+  font-size: 0.75rem;
+  color: var(--muted-color);
+}
+
+.settings-category-item button {
+  background: var(--danger-bg);
+  color: #fff;
+  border: none;
+  border-radius: 0.5rem;
+  padding: 0.4rem 0.8rem;
+  cursor: pointer;
+}
+
+.settings-category-item button:disabled {
+  opacity: 0.4;
+  cursor: not-allowed;
+}
+
+.settings-theme {
+  border: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  gap: 1rem;
+}
+
+.settings-theme label {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  cursor: pointer;
+}
+
+.settings-theme input {
+  accent-color: #6366f1;
+}
+
+.settings-error {
+  margin: 0;
+  color: var(--danger-bg);
+  font-weight: 600;
 }
 
 .task-card--design {

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,11 +1,11 @@
 export type TaskStatus = 'new' | 'in-progress' | 'done';
 
-export type TaskCategory =
-  | 'design'
-  | 'development'
-  | 'research'
-  | 'marketing'
-  | 'support';
+export type TaskCategory = string;
+
+export interface TaskCategoryOption {
+  id: TaskCategory;
+  label: string;
+}
 
 export interface TaskTimer {
   durationMinutes: number;


### PR DESCRIPTION
## Summary
- add a settings modal with category CRUD and theme controls persisted in localStorage
- update task components to use dynamic categories and refresh styling for light/dark themes
- cover category management and theme persistence with new tests

## Testing
- npm test
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68deac7777548325bd1718410e06fed2