### PR TITLE
Fix TaskModal state initialization and remove duplicate imports

### DIFF
--- a/src/components/TaskCard.tsx
+++ b/src/components/TaskCard.tsx
@@ -2,7 +2,6 @@ import { useMemo, useRef, useState } from 'react';
 import type { KeyboardEvent } from 'react';
 import TimerBar from './TimerBar';
 import TaskEditModal from './TaskEditModal';
-import { CATEGORIES, STATUSES } from '../hooks/useTaskBoard';
 import { TASK_PLACEHOLDER_CONTENT } from '../constants/taskContent';
 import { STATUSES, useTaskBoard } from '../hooks/useTaskBoard';
 import type { Task, TaskStatus, TaskUpdate } from '../types';

--- a/src/components/TaskEditModal.tsx
+++ b/src/components/TaskEditModal.tsx
@@ -1,7 +1,6 @@
 import { type MouseEvent, useEffect, useMemo, useState } from 'react';
 import { createPortal } from 'react-dom';
 import RichTextEditor from './RichTextEditor';
-import { CATEGORIES, STATUSES } from '../hooks/useTaskBoard';
 import { normalizeTaskContent } from '../utils/richText';
 import { STATUSES, useTaskBoard } from '../hooks/useTaskBoard';
 import type { Task, TaskCategory, TaskStatus, TaskTimer, TaskUpdate } from '../types';

--- a/src/components/TaskModal.tsx
+++ b/src/components/TaskModal.tsx
@@ -1,12 +1,8 @@
-import { FormEvent, useEffect, useState } from 'react';
+import { FormEvent, useEffect, useMemo, useState } from 'react';
 import RichTextEditor from './RichTextEditor';
-import { CATEGORIES } from '../hooks/useTaskBoard';
-import { DEFAULT_TASK_DESCRIPTION } from '../constants';
 import { normalizeTaskContent } from '../utils/richText';
 
 import { TASK_PLACEHOLDER_CONTENT } from '../constants/taskContent';
-
-import { FormEvent, useEffect, useMemo, useState } from 'react';
 import { useTaskBoard } from '../hooks/useTaskBoard';
 import type { TaskCategory } from '../types';
 
@@ -20,26 +16,14 @@ const TaskModal = ({ isOpen, onClose, onCreate }: TaskModalProps) => {
   const { categories } = useTaskBoard();
   const [title, setTitle] = useState('');
   const [category, setCategory] = useState<TaskCategory>('development');
-  const [content, setContent] = useState(DEFAULT_TASK_DESCRIPTION);
   const [content, setContent] = useState(TASK_PLACEHOLDER_CONTENT);
-  const [category, setCategory] = useState<TaskCategory>('');
-  const [content, setContent] = useState(DEFAULT_CONTENT);
-
-
-
   const fallbackCategory = useMemo(() => categories[0]?.id ?? '', [categories]);
 
   useEffect(() => {
     if (isOpen) {
       setTitle('');
-
-      setCategory('development');
-      setContent(DEFAULT_TASK_DESCRIPTION);
+      setCategory(fallbackCategory || 'development');
       setContent(TASK_PLACEHOLDER_CONTENT);
-
-      setCategory(fallbackCategory);
-      setContent(DEFAULT_CONTENT);
-
     }
   }, [isOpen, fallbackCategory]);
 
@@ -63,9 +47,6 @@ const TaskModal = ({ isOpen, onClose, onCreate }: TaskModalProps) => {
     }
 
     const normalizedContent = normalizeTaskContent(content);
-    const normalizedContent = content.trim() ? content : TASK_PLACEHOLDER_CONTENT;
-
-
     onCreate({
       title: trimmedTitle,
       category: category || fallbackCategory,


### PR DESCRIPTION
## Summary
- remove duplicate React imports and redundant state declarations in TaskModal
- ensure the modal resets to the placeholder content before creating a task
- clean duplicate imports in TaskCard and TaskEditModal to avoid redeclaration errors

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68deb4f4b1808325b96eb14937b7769a