### PR TITLE
Fix TaskModal open reset timing and add regression test

### DIFF
--- a/src/components/TaskModal.tsx
+++ b/src/components/TaskModal.tsx
@@ -1,4 +1,4 @@
-import { FormEvent, useEffect, useMemo, useState } from 'react';
+import { FormEvent, useEffect, useMemo, useRef, useState } from 'react';
 import RichTextEditor from './RichTextEditor';
 import { normalizeTaskContent } from '../utils/richText';
 
@@ -19,13 +19,20 @@ const TaskModal = ({ isOpen, onClose, onCreate }: TaskModalProps) => {
   const [content, setContent] = useState(TASK_PLACEHOLDER_CONTENT);
   const fallbackCategory = useMemo(() => categories[0]?.id ?? '', [categories]);
 
+  const wasOpenRef = useRef(false);
+
   useEffect(() => {
-    if (isOpen) {
+    const wasOpen = wasOpenRef.current;
+
+    if (!wasOpen && isOpen) {
       setTitle('');
       setCategory(fallbackCategory || 'development');
       setContent(TASK_PLACEHOLDER_CONTENT);
     }
-  }, [isOpen, fallbackCategory]);
+
+    wasOpenRef.current = isOpen;
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [isOpen]);
 
   useEffect(() => {
     if (!isOpen) {

--- a/src/components/__tests__/TaskModal.test.tsx
+++ b/src/components/__tests__/TaskModal.test.tsx
@@ -1,0 +1,102 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, within } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import {
+  createContext,
+  useContext,
+  useMemo,
+  useState,
+  type PropsWithChildren
+} from 'react';
+
+import type { TaskCategoryOption } from '../../types';
+
+type MockTaskBoardValue = {
+  categories: TaskCategoryOption[];
+};
+
+const MockTaskBoardContext = createContext<MockTaskBoardValue | null>(null);
+
+const MockTaskBoardProvider = ({
+  categories,
+  children
+}: PropsWithChildren<{ categories: TaskCategoryOption[] }>) => {
+  const value = useMemo(() => ({ categories }), [categories]);
+
+  return (
+    <MockTaskBoardContext.Provider value={value}>{children}</MockTaskBoardContext.Provider>
+  );
+};
+
+vi.mock('../../hooks/useTaskBoard', () => ({
+  useTaskBoard: () => {
+    const context = useContext(MockTaskBoardContext);
+
+    if (!context) {
+      throw new Error('MockTaskBoardProvider is required for this test');
+    }
+
+    return context;
+  }
+}));
+
+import TaskModal from '../TaskModal';
+
+describe('TaskModal', () => {
+  beforeEach(() => {
+    Object.defineProperty(document, 'execCommand', {
+      configurable: true,
+      value: vi.fn()
+    });
+  });
+
+  const handleClose = vi.fn();
+  const handleCreate = vi.fn();
+
+  const TestHarness = () => {
+    const [categories, setCategories] = useState<TaskCategoryOption[]>([
+      { id: 'design', label: 'Дизайн' },
+      { id: 'development', label: 'Разработка' }
+    ]);
+
+    return (
+      <MockTaskBoardProvider categories={categories}>
+        <TaskModal isOpen onClose={handleClose} onCreate={handleCreate} />
+        <button
+          type="button"
+          onClick={() =>
+            setCategories([
+              { id: 'research', label: 'Исследование' },
+              { id: 'marketing', label: 'Маркетинг' }
+            ])
+          }
+        >
+          Обновить категории
+        </button>
+      </MockTaskBoardProvider>
+    );
+  };
+
+  it('сохраняет пользовательский ввод при обновлении списка категорий', async () => {
+    const user = userEvent.setup();
+    render(<TestHarness />);
+
+    const modal = screen.getByRole('dialog', { name: 'Новая задача' });
+    const titleInput = within(modal).getByLabelText('Название');
+    const categorySelect = within(modal).getByLabelText('Категория') as HTMLSelectElement;
+    const descriptionEditor = within(modal).getByLabelText('Описание новой задачи');
+
+    await user.clear(titleInput);
+    await user.type(titleInput, 'Срочная задача');
+    await user.selectOptions(categorySelect, 'development');
+
+    await user.click(descriptionEditor);
+    await user.keyboard('{Control>}{KeyA}{/Control}{Backspace}Подробное описание');
+
+    await user.click(screen.getByRole('button', { name: 'Обновить категории' }));
+
+    expect(titleInput).toHaveValue('Срочная задача');
+    expect(categorySelect.value).toBe('research');
+    expect(descriptionEditor).toHaveTextContent('Подробное описание');
+  });
+});


### PR DESCRIPTION
## Summary
- gate the TaskModal reset effect so it only fires when the dialog transitions from closed to open
- keep the category validity guard while preventing the title and content from being reset when categories change
- add a TaskModal regression test that ensures user input survives category list updates

## Testing
- npm test -- --run TaskModal

------
https://chatgpt.com/codex/tasks/task_e_68deb7c37620832594d77e005445db46